### PR TITLE
Update GitHubbers in Member list

### DIFF
--- a/MEMBERS.csv
+++ b/MEMBERS.csv
@@ -7,11 +7,11 @@ James Christopherson, james.christopherson@target.com, digitaljames, Target
 Luke Faraone, lfaraone@dropbox.com, lfaraone, Dropbox
 Paul Holland, paul.holland@hpe.com, pholland, Hewlett Packard Enterprise
 Jeffrey Jagoda, jeffrey.jagoda@ibm.com, jagoda, IBM
-Brandon Keepers, bkeepers@github.com, bkeepers, GitHub
+Jamie Jones, jbjonesjr@github.com, jbjonesjr, GitHub
+Jeff McAffer, jeffmcaffer@github.com, jeffmcaffer, GitHub
 Chris Kelly, ck@github.com, amateurhuman, GitHub
 Pete Kronowitt, Pete.Kronowitt@intel.com, PeteKronowitt, Intel
 Will Norris, willnorris@google.com, willnorris, Google
-Jeff McAffer, jeffmcaffer@github.com, jeffmcaffer, GitHub
 James Pearce, jamesgpearce@fb.com, jamesgpearce, Facebook
 Gianugo Rabellino, gianugo.rabellino@microsoft.com, gianugo, Microsoft
 Matthew Taylor, matt@numenta.org, rhyolight, Numenta


### PR DESCRIPTION
- Swap jbjonesjr for bkeepers (Taking some of his load is how I got here in the first place, especially now that he is off ⛵️ )
- Move @jeffmcaffer to the GitHub grouping so he isn't so lonely

