### PR TITLE
Update MEMBERS.csv

### DIFF
--- a/MEMBERS.csv
+++ b/MEMBERS.csv
@@ -30,7 +30,8 @@ Stormy Peters, stpeters@redhat.com, -, Red Hat
 Craig Northway, craign@qti.qualcomm.com, craigez, Qualcomm Technologies Inc
 Jaehun Lee, jaehun12.lee@samsung.com, -, Samsung
 Jared Smith, jared.smith@capitalone.com, jaredsmith, Capital One
-Chris Xie, chris.xie@huawei.com, -, Huawei
+Chris Xie, chris.xie@huawei.com, -, Futurewei
+Jie Liu, liujiejo@huawei.com, -, Huawei
 Guy Martin, guy.martin@autodesk.com, guymartin, Autodesk
 Simon MacDonald, smacdona@adobe.com, macdonst, Adobe
 Patrick Steele-Idem, psteeleidem@ebay.com, patrick-steele-idem, eBay


### PR DESCRIPTION
Adjustment:  Chris Xie represent FutureWei while Jie Liu (new added) represent Huawei.